### PR TITLE
Allow different vendor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ In gatsby-config.js
   options: {
     files: ['post/**/index.html', 'index.html'],
     publicPath: 'public',
+    vendor: 'gtag',
     gaConfigPath: 'gaConfig.json',
     dist: 'public/dist',
     optimize: true,
@@ -39,11 +40,14 @@ In gatsby-config.js
   - amp-analytics config json for [google analytics](https://www.ampproject.org/docs/analytics/analytics-vendors)
   - The path is from `publicPath`
   - Optional
+- vendor
+  - add your vendor, (https://www.ampproject.org/docs/analytics/analytics-vendors)
+  - defaults to 'googleanalytics'
 - dist
   - Path to output
   - If the options is not set files are override by AMP result
 - optimize
-  - If true, this module will optimize the html by using [@ampproject/toolbox-optimizer](https://github.com/ampproject/amp-toolbox/tree/master/packages/optimizer) 
+  - If true, this module will optimize the html by using [@ampproject/toolbox-optimizer](https://github.com/ampproject/amp-toolbox/tree/master/packages/optimizer)
 - htmlPlugins
   - you can add custom converter for html
 - cssPlugins

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,13 +9,14 @@ exports.onPostBuild = (_, pluginOptions) => {
     files: ['**/*.html'],
     publicPath: 'public',
     gaConfigPath: null,
+    vendor: 'googleanalytics',
     dist: null,
     serviceWorker: null,
     optimize: false,
     htmlPlugins: [],
     cssPlugins: []
   }
-  const { files, publicPath, gaConfigPath, dist, serviceWorker, optimize, htmlPlugins, cssPlugins } = {
+  const { files, publicPath, gaConfigPath, vendor, dist, serviceWorker, optimize, htmlPlugins, cssPlugins } = {
     ...defaultOptions,
     ...pluginOptions
   }
@@ -25,6 +26,7 @@ exports.onPostBuild = (_, pluginOptions) => {
   const htmls = globby.sync(absolutePaths)
   const config = {
     gaConfigPath,
+    vendor,
     cwd: slash(path.join(process.cwd(), publicPath)),
     serviceWorker,
     optimize,


### PR DESCRIPTION
Hi, we are using this package, but bumped into an issue because our vendor is not googleanalytics, but gtag. With this PR, I would like the user to be able to add a different vendor, while defaulting to googleanalytics. 
Please note that this change also implies a change in your repo [https://github.com/tomoyukikashiro/html2amp](url) for which I will make another PR.